### PR TITLE
[CPL-20326] Update jsonschema dependency to 4.17.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="singer-python",
       url="http://singer.io",
       install_requires=[
           'pytz>=2024.1',
-          'jsonschema>=4.22.0,==4.*',
+          'jsonschema~=4.17.3,<4.18.0',
           'simplejson>=3.19.2,==3.*',
           'python-dateutil>=2.8.2,==2.*',
           'backoff>=2.2.1,==2.*',

--- a/singer/transform.py
+++ b/singer/transform.py
@@ -3,8 +3,6 @@ import decimal
 import logging
 import re
 
-# TODO: Deprecated jsonschema API. Migrate to new one as described in docs:
-# https://python-jsonschema.readthedocs.io/en/v4.22.0/referencing/#migrating-from-refresolver
 from jsonschema import RefResolver
 
 import singer.metadata


### PR DESCRIPTION
# Description of change
[Ticket link](https://railsware.atlassian.net/browse/CPL-20326)
We need to align `jsonschema` dependency with [Airbyte CDK](https://github.com/airbytehq/airbyte-python-cdk/blob/main/pyproject.toml) to be able to install it into the default resolve
